### PR TITLE
made AWS credentials optional

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -22,11 +22,13 @@ source env.sh
 
 # Configure AWS CLI
 mkdir -p .aws
+if [ ! -z "$AWS_ACCESS_KEY_ID" ]; then
 cat <<EOF > .aws/credentials
 [default]
 aws_access_key_id = ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
 EOF
+fi
 if [ ! -z "$AWS_DEFAULT_REGION" ]; then
 cat <<EOF > .aws/config
 [default]


### PR DESCRIPTION
In case your docker host is a EC2 instance itself, the S3 access can be granted via IAM instance role. But this only works if AWS credentials are not passed directly to the CLI.