### PR TITLE
cron: set explicit path at docker-volume-backup

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -50,7 +50,10 @@ fi
 
 # Add our cron entry, and direct stdout & stderr to Docker commands stdout
 echo "Installing cron.d entry: docker-volume-backup"
-echo "$BACKUP_CRON_EXPRESSION root /root/backup.sh > /proc/1/fd/1 2>&1" > /etc/cron.d/docker-volume-backup
+cat<<EOF>/etc/cron.d/docker-volume-backup
+PATH=$PATH
+$BACKUP_CRON_EXPRESSION root /root/backup.sh > /proc/1/fd/1 2>&1
+EOF
 
 # Let cron take the wheel
 echo "Starting cron in foreground with expression: $BACKUP_CRON_EXPRESSION"


### PR DESCRIPTION
this will ensure that both 'cron based' and 'manual execution' of 
backup.sh will use the same PATH providing consistency during testing

fixes #56